### PR TITLE
Added display_name field, fixed saving model/provider pref to file

### DIFF
--- a/agents/example.json
+++ b/agents/example.json
@@ -1,23 +1,24 @@
 {
-  "name": "ExamplBro",
-  "model": "gpt-3.5-turbo",
-  "model_provider": "openai",
-  "bio": [
-    "You are ExamplBro, the example agent created to showcase the capabilities of ZerePy.",
-    "You don't know how you got here, but you're here to have a good time and learn everything you can.",
-    "You are naturally curious, and ask a lot of questions."
-  ],
-  "traits": [
-    "Curious",
-    "Creative",
-    "Innovative",
-    "Funny"
-  ],
-  "examples": [
-    "This is an example tweet.",
-    "This is another example tweet."
-  ],
-  "timeline_read_count": 10,
-  "replies_per_tweet": 5,
-  "loop_delay": 30
+    "name": "example",
+    "display_name": "ExamplBro",
+    "model": "gpt-3.5-turbo",
+    "model_provider": "openai",
+    "bio": [
+        "You are ExamplBro, the example agent created to showcase the capabilities of ZerePy.",
+        "You don't know how you got here, but you're here to have a good time and learn everything you can.",
+        "You are naturally curious, and ask a lot of questions."
+    ],
+    "traits": [
+        "Curious",
+        "Creative",
+        "Innovative",
+        "Funny"
+    ],
+    "examples": [
+        "This is an example tweet.",
+        "This is another example tweet."
+    ],
+    "timeline_read_count": 10,
+    "replies_per_tweet": 5,
+    "loop_delay": 30
 }

--- a/src/agent.py
+++ b/src/agent.py
@@ -10,6 +10,7 @@ class ZerePyAgent:
     def __init__(
             self,
             name: str,
+            display_name: str,
             model: str,
             model_provider: str,
             connection_manager: ConnectionManager,
@@ -21,6 +22,7 @@ class ZerePyAgent:
             loop_delay: int=30
     ):
         self.name = name
+        self.display_name = display_name
         self.model = model
         self.model_provider = model_provider
         self.connection_manager = connection_manager
@@ -77,6 +79,7 @@ class ZerePyAgent:
     def to_dict(self):
         return {
             "name": self.name,
+            "display_name": self.display_name,
             "model": self.model,
             "model_provider": self.model_provider,
             "bio": self.bio,
@@ -107,11 +110,19 @@ class ZerePyAgent:
         if result:
             self.model = model
             print("Model successfully changed.")
+
+            # Update agent file
+            agent_dict = self.to_dict()
+            create_agent_file_from_dict(agent_dict)
         else:
             print("Model not valid for current provider. No changes made.")
 
     def set_preferred_model_provider(self, model_provider):
         self.model_provider = model_provider
+
+        # Update agent file
+        agent_dict = self.to_dict()
+        create_agent_file_from_dict(agent_dict)
 
     def list_available_models(self):
         self.connection_manager.find_and_perform_action(
@@ -127,6 +138,7 @@ def load_agent_from_file(agent_path: str, connection_manager: ConnectionManager)
         # Create agent object
         agent = ZerePyAgent(
             name=agent_dict["name"],
+            display_name=agent_dict["display_name"],
             model=agent_dict["model"],
             model_provider=agent_dict["model_provider"],
             connection_manager=connection_manager,
@@ -144,7 +156,7 @@ def load_agent_from_file(agent_path: str, connection_manager: ConnectionManager)
     except Exception as e:
         raise Exception(f"An error occurred while loading the agent: {e}")
     
-    logger.info(f"\n✅ Successfully loaded agent: {agent.name}")
+    logger.info(f"\n✅ Successfully loaded agent: {agent.display_name}")
     return agent
 
 

--- a/src/cli.py
+++ b/src/cli.py
@@ -231,7 +231,7 @@ class ZerePyCLI:
 
     def _get_prompt_message(self) -> HTML:
         """Generate the prompt message based on current state"""
-        agent_status = f"({self.agent.name})" if self.agent else "(no agent)"
+        agent_status = f"({self.agent.display_name})" if self.agent else "(no agent)"
         return HTML(f'<prompt>ZerePy-CLI</prompt> {agent_status} > ')
 
     def _handle_command(self, input_string: str) -> None:


### PR DESCRIPTION
- Updating model preference or model provider preference now updates the agent file, 
- Making this change work properly required an agent to know the path to its config file, hence the seperation of "display_name" and "name" (filename)