### PR TITLE
Check username and throw err if not found

### DIFF
--- a/src/agent.py
+++ b/src/agent.py
@@ -68,7 +68,7 @@ class ZerePyAgent:
         load_dotenv()
         self.username = os.getenv('TWITTER_USERNAME', '').lower()
         if not self.username:
-                raise KeyError("Twitter username is required")
+                raise ValueError("Twitter username is required")
 
     def _construct_system_prompt(self) -> str:
         """Construct the system prompt from agent configuration"""

--- a/src/agent.py
+++ b/src/agent.py
@@ -67,6 +67,8 @@ class ZerePyAgent:
         # Load Twitter username for self-reply detection
         load_dotenv()
         self.username = os.getenv('TWITTER_USERNAME', '').lower()
+        if not self.username:
+                raise KeyError("Twitter username is required")
 
     def _construct_system_prompt(self) -> str:
         """Construct the system prompt from agent configuration"""


### PR DESCRIPTION
I started a fresh example agent and ran into this error:

```
Starting loop in 5 seconds...
5...
4...
3...
2...
1...

❌ Error in agent loop iteration: object of type 'NoneType' has no len()
```

It was fixed after adding `TWITTER_USERNAME` to `.env`

There are multiple ways to fix it, maybe fetching from `TWITTER_USER_ID`? Throwing a better error seems like a good start.