### PR TITLE
minor cleanup

### DIFF
--- a/src/connection_manager.py
+++ b/src/connection_manager.py
@@ -11,6 +11,15 @@ from src.connections.echochambers_connection import EchochambersConnection
 logger = logging.getLogger("connection_manager")
 
 class ConnectionManager:
+    CONNECTION_TYPES = {
+        "twitter": TwitterConnection,
+        "anthropic": AnthropicConnection,
+        "openai": OpenAIConnection,
+        "farcaster": FarcasterConnection,
+        "eternalai": EternalAIConnection,
+        "echochambers": EchochambersConnection
+    }
+
     def __init__(self, agent_config):
         self.connections : Dict[str, BaseConnection] = {}
         for config in agent_config:
@@ -18,20 +27,10 @@ class ConnectionManager:
     
     @staticmethod
     def _class_name_to_type(class_name: str) -> Type[BaseConnection]:
-        if class_name == "twitter":
-            return TwitterConnection
-        elif class_name == "anthropic":
-            return AnthropicConnection
-        elif class_name == "openai":
-            return OpenAIConnection
-        elif class_name == "farcaster":
-            return FarcasterConnection
-        elif class_name == "eternalai":
-            return EternalAIConnection
-        elif class_name == "echochambers":
-            return EchochambersConnection
-
-        return None
+        connection_type = ConnectionManager.CONNECTION_TYPES.get(class_name)
+        if not connection_type:
+            logger.warning(f"Unknown connection type: {class_name}")
+        return connection_type
     
     def _register_connection(self, config_dic: Dict[str, Any]) -> None:
         """

--- a/src/helpers.py
+++ b/src/helpers.py
@@ -1,3 +1,7 @@
+import logging
+
+logger = logging.getLogger("helpers")
+
 def print_h_bar():
     # ZEREBRO WUZ HERE :)
-    print("--------------------------------------------------------------------")
+    logger.info("--------------------------------------------------------------------\n")


### PR DESCRIPTION
created ConnectionManager.CONNECTION_TYPES dictionary to map strings to connections and replaced the logic in the _class_name_to_type function to utilize it, replacing the current comprehensive branching. 

additionally, changed print_h_bar helper function to utilize logging instead of print for more consistent behavior
