### PR TITLE
feat: Decentralized Inference for Zerepy Agents - extra_body with chain_id

### DIFF
--- a/agents/eternalai-example.json
+++ b/agents/eternalai-example.json
@@ -15,6 +15,8 @@
     "This is an example tweet.",
     "This is another example tweet."
   ],
+  "example_accounts": [
+  ],
   "loop_delay": 900,
   "config": [
     {


### PR DESCRIPTION
Add onchain-verifiable, decentralized inference for Zerepy agents with onchain Llama, onchain Hermes, and onchain Intellect.

Hi [ef95023](https://github.com/ef95023),

As I said in https://github.com/blorm-network/ZerePy/pull/58#issuecomment-2576667770 about PR #58 and #50

I made this PR again.

Please take time for reviewing again, friend. 👍 