### PR TITLE
feats: added get-provider-info and change-llm-provider to cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,8 @@ Create a new JSON file in the `agents` directory following this structure:
   ],
   "traits": ["Curious", "Creative", "Innovative", "Funny"],
   "examples": ["This is an example tweet.", "This is another example tweet."],
-  "example_accounts" : ["X_username_to_use_for_tweet_examples"]
+  "example_accounts": ["X_username_to_use_for_tweet_examples"],
+  "default_provider": "hyperbolic", // optional, defaults to openai
   "loop_delay": 900,
   "config": [
     {
@@ -224,6 +225,8 @@ Use `help` in the CLI to see all available commands. Key commands include:
 - `list-actions`: Show available actions for a connection
 - `configure-connection`: Set up a new connection
 - `chat`: Start interactive chat with agent
+- `get-provider-info`: Show current LLM provider and model
+- `change-llm-provider`: Change the active LLM provider
 
 ## Star History
 

--- a/agents/example.json
+++ b/agents/example.json
@@ -18,6 +18,7 @@
   "example_accounts": [
     "0xzerebro"
   ],
+  "default_provider": "openai",
   "loop_delay": 900,
   "config": [
     {

--- a/src/cli.py
+++ b/src/cli.py
@@ -176,7 +176,30 @@ class ZerePyCLI:
                 aliases=['connections', 'ls-connections']
             )
         )
-        
+
+        #get info on current llm provider and model
+        self._register_command(
+            Command(
+                name="get-provider-info",
+                description="Shows information about the current LLM provider and model.",
+                tips=["Run this command to see which LLM provider and model is currently being used"],
+                handler=self.get_provider_info,
+                aliases=['provider-info', 'provider']
+            )
+        )
+
+        # Change provider command - note explicit parameter format in tips
+        self._register_command(
+            Command(
+                name="change-llm-provider", 
+                description="Changes the LLM provider being used.",
+                tips=["Format: change-llm-provider {provider_name}",
+                    "Use 'list-connections' to see available providers"],
+                handler=self.change_provider,
+                aliases=['set-provider']
+            )
+        )
+                
         ################## MISC ################## 
         # Exit command
         self._register_command(
@@ -484,6 +507,33 @@ class ZerePyCLI:
             self.agent.connection_manager.list_connections()
         else:
             logging.info("Please load an agent to see the list of supported actions")
+
+    def get_provider_info(self, input_list: List[str]) -> None:
+        """Display current LLM provider and model information"""
+        if not self.agent:
+            logger.info("No agent is currently loaded")
+            return
+            
+        info = self.agent.get_current_provider_info()
+        logger.info(f"\nCurrent LLM Provider: {info['provider']}")
+        logger.info(f"Using Model: {info['model']}")
+
+    def change_provider(self, input_list: List[str]) -> None:
+        """Change the current LLM provider"""
+        if not self.agent:
+            logger.info("No agent is currently loaded")
+            return
+            
+        if len(input_list) != 2:  # Command name + exactly one argument
+            logger.info("Please specify exactly one provider name")
+            logger.info("Format: change-llm-provider {provider_name}")
+            return
+            
+        provider = input_list[1]
+        if self.agent.change_llm_provider(provider):
+            logger.info(f"\n✅ Successfully changed provider to {provider}")
+        else:
+            logger.info("\nUse 'list-connections' to see available providers")
 
     def chat_session(self, input_list: List[str]) -> None:
         """Handle chat command"""


### PR DESCRIPTION
get-provider-info and change-llm-provider now work directly from cli without agent-action. also added an optional field in the config for default -provider, which defaults to openai when not provided. additionally, relevant documentation was provided in minimally spanning form.