### PR TITLE
Twitter Stream Depth

### DIFF
--- a/agents/example.json
+++ b/agents/example.json
@@ -27,7 +27,7 @@
       "tweet_interval": 5400,
       "respond_to_mentions": {
         "enabled": false,
-        "accounts_mentioned": ["0xzerebro"],
+        "accounts_mentioned": ["blormmy"],
         "accounts_to_listen_to": ["0xzerebro"]
       }
     },

--- a/agents/example.json
+++ b/agents/example.json
@@ -26,7 +26,7 @@
       "own_tweet_replies_count":2,
       "tweet_interval": 5400,
       "respond_to_mentions": {
-        "enabled": true,
+        "enabled": false,
         "accounts_mentioned": ["0xzerebro"],
         "accounts_to_listen_to": ["0xzerebro"]
       }

--- a/agents/example.json
+++ b/agents/example.json
@@ -25,7 +25,11 @@
       "timeline_read_count": 10,
       "own_tweet_replies_count":2,
       "tweet_interval": 5400,
-      "respond_to_mentions": false
+      "respond_to_mentions": {
+        "enabled": true,
+        "accounts_mentioned": ["0xzerebro"],
+        "accounts_to_listen_to": ["0xzerebro"]
+      }
     },
     {
       "name": "farcaster",

--- a/agents/example.json
+++ b/agents/example.json
@@ -24,7 +24,8 @@
       "name": "twitter",
       "timeline_read_count": 10,
       "own_tweet_replies_count":2,
-      "tweet_interval": 5400
+      "tweet_interval": 5400,
+      "respond_to_mentions": false
     },
     {
       "name": "farcaster",

--- a/src/actions/twitter_actions.py
+++ b/src/actions/twitter_actions.py
@@ -107,15 +107,9 @@ def respond_to_mentions(agent,**kwargs): #REQUIRES TWITTER PREMIUM PLAN
     def process_tweets():
         for tweet_data in stream_function:
             try:
-                tweet_id = tweet_data["id"]
-                tweet = agent.connection_manager.perform_action(
-                    connection_name="twitter",
-                    action_name="get-tweet-details",
-                    params=[tweet_id]
-                )
-                tweet_author = tweet.get("author_username", "")
-                tweet_text = tweet.get("text", "")
-
+                tweet_id = tweet_data.get("id", "")
+                tweet_author = tweet_data.get("author_username", "")
+                tweet_text = tweet_data.get("text", "")
                 agent.logger.info(f"Received a mention from @{tweet_author}: {tweet_text}")            
             except Exception as e:
                 agent.logger.error(f"Error processing tweet in stream: {str(e)}")

--- a/src/actions/twitter_actions.py
+++ b/src/actions/twitter_actions.py
@@ -106,7 +106,7 @@ def respond_to_mentions(agent,**kwargs): #REQUIRES TWITTER PREMIUM PLAN
     user_ids = agent.connection_manager.perform_action(
         connection_name="twitter",
         action_name="get-user-details",
-        params = [None, accounts_to_listen_to]
+        params = [[], accounts_to_listen_to]
     )
     if user_ids:
         accounts_to_listen_to_ids = [user.get('id') for user in user_ids]

--- a/src/actions/twitter_actions.py
+++ b/src/actions/twitter_actions.py
@@ -106,9 +106,20 @@ def respond_to_mentions(agent,**kwargs): #REQUIRES TWITTER PREMIUM PLAN
     )
     def process_tweets():
         for tweet_data in stream_function:
-            tweet_id = tweet_data["id"]
-            tweet_text = tweet_data["text"]
-            agent.logger.info(f"Received a mention: {tweet_text}")
+            try:
+                tweet_id = tweet_data["id"]
+                tweet = agent.connection_manager.perform_action(
+                    connection_name="twitter",
+                    action_name="get-tweet-details",
+                    params=[tweet_id]
+                )
+                tweet_author = tweet.get("author_username", "")
+                tweet_text = tweet.get("text", "")
+
+                agent.logger.info(f"Received a mention from @{tweet_author}: {tweet_text}")            
+            except Exception as e:
+                agent.logger.error(f"Error processing tweet in stream: {str(e)}")
+                continue
 
     processing_thread = threading.Thread(target=process_tweets)
     processing_thread.daemon = True

--- a/src/actions/twitter_actions.py
+++ b/src/actions/twitter_actions.py
@@ -108,9 +108,10 @@ def respond_to_mentions(agent,**kwargs): #REQUIRES TWITTER PREMIUM PLAN
         for tweet_data in stream_function:
             try:
                 tweet_id = tweet_data.get("id", "")
-                tweet_author = tweet_data.get("author_username", "")
                 tweet_text = tweet_data.get("text", "")
-                agent.logger.info(f"Received a mention from @{tweet_author}: {tweet_text}")            
+                author_id = tweet_data.get("author_id", "")
+                author_username = tweet_data.get("author_username", "")
+                agent.logger.info(f"Received a mention from @{author_username}: {tweet_text}")            
             except Exception as e:
                 agent.logger.error(f"Error processing tweet in stream: {str(e)}")
                 continue

--- a/src/agent.py
+++ b/src/agent.py
@@ -192,7 +192,7 @@ class ZerePyAgent:
                 try:
                     # REPLENISH INPUTS
                     # TODO: Add more inputs to complexify agent behavior
-                    '''if "timeline_tweets" not in self.state or self.state["timeline_tweets"] is None or len(self.state["timeline_tweets"]) == 0:
+                    if "timeline_tweets" not in self.state or self.state["timeline_tweets"] is None or len(self.state["timeline_tweets"]) == 0:
                         if (self.has_twitter_tasks):
                             logger.info("\n👀 READING TIMELINE")
                             self.state["timeline_tweets"] = self.connection_manager.perform_action(
@@ -208,7 +208,7 @@ class ZerePyAgent:
                                 connection_name="echochambers",
                                 action_name="get-room-info",
                                 params={}
-                            )'''
+                            )
 
                     # CHOOSE AN ACTION
                     # TODO: Add agentic action selection

--- a/src/agent.py
+++ b/src/agent.py
@@ -40,13 +40,14 @@ class ZerePyAgent:
             self.use_time_based_weights = agent_dict["use_time_based_weights"]
             self.time_based_multipliers = agent_dict["time_based_multipliers"]
 
-            has_twitter_tasks = any("tweet" in task["name"] for task in agent_dict.get("tasks", []))
+            self.has_twitter_tasks = any("tweet" in task["name"] for task in agent_dict.get("tasks", []))
             
             twitter_config = next((config for config in agent_dict["config"] if config["name"] == "twitter"), None)
             
-            if has_twitter_tasks and twitter_config:
+            if self.has_twitter_tasks and twitter_config:
                 self.tweet_interval = twitter_config.get("tweet_interval", 900)
                 self.own_tweet_replies_count = twitter_config.get("own_tweet_replies_count", 2)
+                self.respond_to_mentions = twitter_config.get("respond_to_mentions", False)  
 
             # Extract Echochambers config
             echochambers_config = next((config for config in agent_dict["config"] if config["name"] == "echochambers"), None)
@@ -79,7 +80,7 @@ class ZerePyAgent:
         self.model_provider = llm_providers[0]
 
         # Load Twitter username for self-reply detection if Twitter tasks exist
-        if any("tweet" in task["name"] for task in self.tasks):
+        if self.has_twitter_tasks:
             load_dotenv()
             self.username = os.getenv('TWITTER_USERNAME', '').lower()
             if not self.username:
@@ -172,6 +173,11 @@ class ZerePyAgent:
             logger.info(f"{i}...")
             time.sleep(1)
 
+        if self.has_twitter_tasks:
+            if self.respond_to_mentions:
+                logger.info("\n👀 Listening for mentions...")
+                execute_action(self, "respond-to-mentions")
+          
         try:
             while True:
                 success = False
@@ -179,7 +185,7 @@ class ZerePyAgent:
                     # REPLENISH INPUTS
                     # TODO: Add more inputs to complexify agent behavior
                     if "timeline_tweets" not in self.state or self.state["timeline_tweets"] is None or len(self.state["timeline_tweets"]) == 0:
-                        if any("tweet" in task["name"] for task in self.tasks):
+                        if (self.has_twitter_tasks):
                             logger.info("\n👀 READING TIMELINE")
                             self.state["timeline_tweets"] = self.connection_manager.perform_action(
                                 connection_name="twitter",

--- a/src/agent.py
+++ b/src/agent.py
@@ -47,7 +47,14 @@ class ZerePyAgent:
             if self.has_twitter_tasks and twitter_config:
                 self.tweet_interval = twitter_config.get("tweet_interval", 900)
                 self.own_tweet_replies_count = twitter_config.get("own_tweet_replies_count", 2)
-                self.respond_to_mentions = twitter_config.get("respond_to_mentions", False)  
+                respond_to_mentions_config = twitter_config.get("respond_to_mentions", None)
+
+                if (respond_to_mentions_config):
+                    self.respond_to_mentions = respond_to_mentions_config.get("enabled", False)
+                    self.accounts_mentioned = respond_to_mentions_config.get("accounts_mentioned", [])
+                    self.accounts_to_listen_to = respond_to_mentions_config.get("accounts_to_listen_to", [])
+                else:
+                    self.respond_to_mentions = False
 
             # Extract Echochambers config
             echochambers_config = next((config for config in agent_dict["config"] if config["name"] == "echochambers"), None)
@@ -176,15 +183,16 @@ class ZerePyAgent:
         if self.has_twitter_tasks:
             if self.respond_to_mentions:
                 logger.info("\n👀 Listening for mentions...")
-                execute_action(self, "respond-to-mentions")
-          
+                if (len(self.accounts_mentioned) == 0):
+                    self.accounts_mentioned = [self.username] # Default to listening to own mentions if no accounts mentioned
+                execute_action(self, "respond-to-mentions", accounts_mentioned=self.accounts_mentioned, accounts_to_listen_to=self.accounts_to_listen_to) 
         try:
             while True:
                 success = False
                 try:
                     # REPLENISH INPUTS
                     # TODO: Add more inputs to complexify agent behavior
-                    if "timeline_tweets" not in self.state or self.state["timeline_tweets"] is None or len(self.state["timeline_tweets"]) == 0:
+                    '''if "timeline_tweets" not in self.state or self.state["timeline_tweets"] is None or len(self.state["timeline_tweets"]) == 0:
                         if (self.has_twitter_tasks):
                             logger.info("\n👀 READING TIMELINE")
                             self.state["timeline_tweets"] = self.connection_manager.perform_action(
@@ -200,7 +208,7 @@ class ZerePyAgent:
                                 connection_name="echochambers",
                                 action_name="get-room-info",
                                 params={}
-                            )
+                            )'''
 
                     # CHOOSE AN ACTION
                     # TODO: Add agentic action selection

--- a/src/connections/twitter_connection.py
+++ b/src/connections/twitter_connection.py
@@ -93,6 +93,14 @@ class TwitterConnection(BaseConnection):
                 ],
                 description="Fetch tweet replies"
             ),
+            "get-user-details": Action(
+                name="get-user-details",
+                parameters=[
+                    ActionParameter("user_ids", True, list, "IDs of the user to get details for"),
+                    ActionParameter("usernames", True, list, "Usernames of the user to get details for")
+                ],
+                description="Get details for user(s) by ID or username"
+            ),
             "get-tweet-details": Action(
                 name="get-tweet-details",
                 parameters=[
@@ -524,6 +532,26 @@ class TwitterConnection(BaseConnection):
         
         logger.info(f"Retrieved {len(replies)} replies")
         return replies
+
+    def get_user_details(self, user_ids: list, usernames: list, **kwargs) -> dict:
+        """Get details for user(s) by ID or username"""
+        logger.debug(f"Getting details for user_ids: {user_ids} or usernames: {usernames}")
+
+        params = {"user.fields": "username"}
+    
+        if user_ids:
+            params["ids"] = ",".join(user_ids)
+            endpoint = "users"
+        else:
+            params["usernames"] = ",".join(usernames)
+            endpoint = f"users/by/"
+
+        response = self._make_request('get', endpoint, params=params)
+    
+        users = response.get("data", [])
+    
+        logger.info("Retrieved user details")
+        return users
     
     def get_tweet_details(self, tweet_id: str, **kwargs) -> dict:
         """Get details for a specific tweet"""

--- a/src/connections/twitter_connection.py
+++ b/src/connections/twitter_connection.py
@@ -581,7 +581,6 @@ class TwitterConnection(BaseConnection):
         rules = self._get_rules()
         self._delete_rules(rules)
         self._build_rule(filter_string)
-        logger.info("Starting Twitter stream")
         try:
             params = {
                 "tweet.fields": "author_id,created_at,text,attachments,referenced_tweets",

--- a/src/connections/twitter_connection.py
+++ b/src/connections/twitter_connection.py
@@ -93,6 +93,13 @@ class TwitterConnection(BaseConnection):
                 ],
                 description="Fetch tweet replies"
             ),
+            "get-tweet-details": Action(
+                name="get-tweet-details",
+                parameters=[
+                    ActionParameter("tweet_id", True, str, "ID of the tweet to get details for")
+                ],
+                description="Get details for a specific tweet"
+            ),
             "stream-tweets": Action(
                 name="stream-tweets",
                 parameters=[
@@ -517,6 +524,27 @@ class TwitterConnection(BaseConnection):
         
         logger.info(f"Retrieved {len(replies)} replies")
         return replies
+    
+    def get_tweet_details(self, tweet_id: str, **kwargs) -> dict:
+        """Get details for a specific tweet"""
+        logger.debug(f"Getting details for tweet {tweet_id}")
+        
+        params = {
+            "tweet.fields": "author_id,created_at,text,attachments,referenced_tweets",
+            "expansions": "author_id",
+            "user.fields": "username",
+            "ids": tweet_id
+        }
+        
+        response = self._make_request('get', 'tweets', params=params)
+        tweet = response.get("data", [])[0]
+
+        if "includes" in response and "users" in response["includes"]:
+            author = response["includes"]["users"][0]
+            tweet["author_username"] = author["username"]
+        
+        logger.info("Retrieved tweet details")
+        return tweet
     
     def _bearer_oauth(self,r):
         bearer_token = self._get_credentials().get("TWITTER_BEARER_TOKEN")


### PR DESCRIPTION
This further improves #119 

- Add Fetch tweet details action 
- Add Fetch user details by list of IDs or list of Usernames action
-  Add Tweet details in stream
- Modify Tweet stream filter to include multiple mentioned accounts and tweet authors

Setup Twitter Listener by adding this in the twitter connection config: 
```   json
 {
      "respond_to_mentions": {
        "enabled": true,
        "accounts_mentioned": ["0xzerebro"], 
        "accounts_to_listen_to": ["0xzerebro"]
}
```

`accounts_mentioned` : Accounts mentioned in tweets that we want to listen to 
`accounts_to_listen_to` : Authors of the tweets to listen to

NOTE: This requires twitter premium plan and bearer set up , refer to #119 