### PR TITLE
Fix previous_content KeyError in post_echochambers

### DIFF
--- a/src/actions/echochamber_actions.py
+++ b/src/actions/echochamber_actions.py
@@ -17,7 +17,7 @@ def post_echochambers(agent, **kwargs):
         
         # Generate message based on room topic and tags
         previous_messages = agent.connection_manager.connections["echochambers"].sent_messages
-        previous_content = "\n".join([f"- {msg['content']}" for msg in previous_messages])
+        previous_content = "\n".join([f"- {msg.get('content', '')}" for msg in previous_messages])
         agent.logger.info(f"Found {len(previous_messages)} messages in post history")
         
         prompt  = POST_ECHOCHAMBER_PROMPT.format(


### PR DESCRIPTION
Replaced msg['content'] with msg.get('content', '') to prevent KeyError if the key is missing.
Improved stability when retrieving previous messages in post_echochambers.
Logging remains unchanged.

This ensures safer execution and prevents potential crashes.