### PR TITLE
Fix docstring in _register_connection method to match actual parameters

### DIFF
--- a/src/connection_manager.py
+++ b/src/connection_manager.py
@@ -80,9 +80,7 @@ class ConnectionManager:
         Create and register a new connection with configuration
 
         Args:
-            name: Identifier for the connection
-            connection_class: The connection class to instantiate
-            config: Configuration dictionary for the connection
+            config_dic: Configuration dictionary containing connection name and settings
         """
         try:
             name = config_dic["name"]


### PR DESCRIPTION

Updates method documentation to correctly reflect the single config_dic parameter instead of outdated multi-parameter format.